### PR TITLE
fix crash when hovering green edition in too many jokers popup

### DIFF
--- a/mossed.lua
+++ b/mossed.lua
@@ -85,8 +85,8 @@ SMODS.Edition{
 		if card.area.config.collection then
 			return {
 				vars = {
-					card.edition.extra.upgrade,
-					card.edition.extra.sell_up,
+					card.edititon and card.edititon.extra and card.edition.extra.upgrade or self.config.extra.upgrade,
+					card.edititon and card.edition.extra and card.edition.extra.sell_up or self.config.extra.sell_up,
 				},
 				key = self.key.."alt2",
 			}


### PR DESCRIPTION
should fix this crash:

```
INFO - [G] 2025-05-04 11:16:27 :: ERROR :: StackTrace :: Oops! The game crashed
[SMODS mossed "mossed.lua"]:90: attempt to index field 'extra' (a nil value)
Stack Traceback
===============
(1) Lua local 'handler' at file 'main.lua:612'
	Local variables:
	 msg = string: "[SMODS mossed \"mossed.lua\"]:90: attempt to index field 'extra' (a nil value)"
	 (*temporary) = Lua function '?' (defined at line 31 of chunk [SMODS _ "src/logging.lua"])
	 (*temporary) = number: 2.29649e-314
	 (*temporary) = string: "Oops! The game crashed\
"
(2) LÖVE metamethod at file 'boot.lua:352'
	Local variables:
	 errhand = Lua function '?' (defined at line 598 of chunk main.lua)
	 handler = Lua function '?' (defined at line 598 of chunk main.lua)
(3) Lua method 'loc_vars' at file 'mossed.lua:90' (from mod with id mossed)
	Local variables:
	 self = table: 0x032a63dce8  {_discovered_unlocked_overwritten:true, order:6, sound:table: 0x032a63df38, weight:3, mod:table: 0x011bbc45b0, calculate:function: 0x032a63e118 (more...)}
	 info_queue = table: 0x0329b9f7d8  {}
	 card = table: 0x011bab9cf8  {sell_cost_label:1, states:table: 0x01196f05f0, VT:table: 0x011b8a47e0, juice:table: 0x011bb4f018, edition:table: 0x032a641e78, original_T:table: 0x011bcaede0 (more...)}
	 area = nil
	 (*temporary) = table: 0x03299fa9d8  {}
	 (*temporary) = table: 0x0329836d78  {}
	 (*temporary) = nil
	 (*temporary) = string: "moss_green: true\
"
	 (*temporary) = number: 1.23516e-322
	 (*temporary) = string: "attempt to index field 'extra' (a nil value)"
(4) Lua method 'generate_ui' at Steamodded file 'src/game_object.lua:1073'
	Local variables:
	 self = table: 0x032a63dce8  {_discovered_unlocked_overwritten:true, order:6, sound:table: 0x032a63df38, weight:3, mod:table: 0x011bbc45b0, calculate:function: 0x032a63e118 (more...)}
	 info_queue = table: 0x0329b9f7d8  {}
	 card = table: 0x011bab9cf8  {sell_cost_label:1, states:table: 0x01196f05f0, VT:table: 0x011b8a47e0, juice:table: 0x011bb4f018, edition:table: 0x032a641e78, original_T:table: 0x011bcaede0 (more...)}
	 desc_nodes = table: 0x01193b9cf0  {}
	 specific_vars = nil
	 full_UI_table = table: 0x032a6e70e8  {info:table: 0x011949a728, type:table: 0x0329ca1f98, card_type:Edition, badges:table: 0x011b8ca9d0, main:table: 0x01193b9cf0}
	 target = table: 0x0119731418  {nodes:table: 0x01193b9cf0, type:descriptions, key:e_moss_green, vars:table: 0x0119610aa8, set:Edition, AUT:table: 0x032a6e70e8}
	 res = table: 0x01196b33e0  {}
(5) Lua method 'generate_UIBox_ability_table' at file 'functions/common_events.lua:2768'
	Local variables:
	 _c = table: 0x032a63dce8  {_discovered_unlocked_overwritten:true, order:6, sound:table: 0x032a63df38, weight:3, mod:table: 0x011bbc45b0, calculate:function: 0x032a63e118 (more...)}
	 full_UI_table = table: 0x032a6e70e8  {info:table: 0x011949a728, type:table: 0x0329ca1f98, card_type:Edition, badges:table: 0x011b8ca9d0, main:table: 0x01193b9cf0}
	 specific_vars = nil
	 card_type = string: "Edition"
	 badges = table: 0x011b8ca9d0  {card_type:Edition}
	 hide_desc = nil
	 main_start = nil
	 main_end = nil
	 card = table: 0x011bab9cf8  {sell_cost_label:1, states:table: 0x01196f05f0, VT:table: 0x011b8a47e0, juice:table: 0x011bb4f018, edition:table: 0x032a641e78, original_T:table: 0x011bcaede0 (more...)}
	 first_pass = boolean: true
	 desc_nodes = table: 0x01193b9cf0  {}
	 name_override = nil
	 info_queue = table: 0x0329b9f7d8  {}
	 loc_vars = table: 0x011bb36608  {}
	 cfg = table: 0x011bc55338  {p_dollars:0, x_mult:1, order:6, bonus:0, h_dollars:0, hands_played_at_create:0, type:, h_x_mult:0, extra_value:0, t_chips:0, h_chips:0, perma_x_mult:0 (more...)}
(6) Lua method 'hover' at file 'card.lua:4583'
	Local variables:
	 self = table: 0x011bab9cf8  {sell_cost_label:1, states:table: 0x01196f05f0, VT:table: 0x011b8a47e0, juice:table: 0x011bb4f018, edition:table: 0x032a641e78, original_T:table: 0x011bcaede0 (more...)}
(7) Lua method 'update' at file 'engine/controller.lua:399'
	Local variables:
	 self = table: 0x01193cf7e0  {released_on:table: 0x01194b4588, collision_list:table: 0x01194a6530, cursor_down:table: 0x011949ec68, cursor_up:table: 0x011946a440, cursor_hover:table: 0x01193ea7b8 (more...)}
	 dt = number: 0.00850427
(8) Lua upvalue 'gameUpdateRef' at file 'game.lua:2686'
	Local variables:
	 self = table: 0x0118fa24a8  {ROOM_PADDING_H:0.7, MOVEABLES:table: 0x01109c1af0, FONTS:table: 0x011bc7a710, STATE_COMPLETE:false, COLLABS:table: 0x0118fa2db0, LANGUAGES:table: 0x011974a550 (more...)}
	 dt = number: 0.00850427
(9) Lua method 'update' at Steamodded file 'src/ui.lua:84'
	Local variables:
	 self = table: 0x0118fa24a8  {ROOM_PADDING_H:0.7, MOVEABLES:table: 0x01109c1af0, FONTS:table: 0x011bc7a710, STATE_COMPLETE:false, COLLABS:table: 0x0118fa2db0, LANGUAGES:table: 0x011974a550 (more...)}
	 dt = number: 0.00850427
(10) Lua field 'update' at file 'main.lua:1021'
	Local variables:
	 dt = number: 0.00850427
(11) Lua function '?' at file 'main.lua:943' (best guess)
(12) global C function 'xpcall'
(13) LÖVE function at file 'boot.lua:377' (best guess)
	Local variables:
	 func = Lua function '?' (defined at line 911 of chunk main.lua)
	 inerror = boolean: true
	 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
	 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])

INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] 2025-05-04 11:16:27 :: INFO  :: StackTrace :: Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-0503b-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.7.1
Platform: OS X
Steamodded Mods:
    1: Too Many Jokers by cg [ID: toomanyjokers, Priority: 1000000, Uses Lovely]
    2: Mossed by Larantula, Jetziel [ID: mossed, Priority: -20, Version: 1.0.0]
Lovely Mods:
```